### PR TITLE
Remove duplicate entries in the method index, fix attribute links 

### DIFF
--- a/lib/hanna-nouveau/template_files/method_index.haml
+++ b/lib/hanna-nouveau/template_files/method_index.haml
@@ -9,7 +9,5 @@
 %ol#search-results{ :class => 'methods', :style => 'display: none' }
 
 %ol#index-entries{ :class => 'methods' }
-  - values[:attributes].each do |entry|
-    %li= link_to_method entry, [classfile(entry.parent), "method-#{entry.html_name}"].join('#')
-  - values[:methods].each do |entry|
+  - (values[:attributes] + values[:methods]).uniq.each do |entry|
     %li= link_to_method entry, [classfile(entry.parent), entry.aref].join('#')


### PR DESCRIPTION
I only noticed the duplicates because they were showing up
in Sequel's RDocs: http://sequel.rubyforge.org/rdoc/index.html.
I've confirmed that the cause is not duplicate files, so I'm not
sure why the duplicates are there.

The links for the attributes were incorrect, since hanna uses
attribute-\* as the anchor for attributes.  Looks like both
respond to aref, so just use that.
