### PR TITLE
Change footer link to "Hanna Nouveau".

### DIFF
--- a/lib/hanna-nouveau/template_files/layout.haml
+++ b/lib/hanna-nouveau/template_files/layout.haml
@@ -31,4 +31,4 @@
         = yield
         #footer-push
       #footer
-        = link_to '<strong>Hanna</strong> RDoc template', 'http://github.com/mislav/hanna/tree/master'
+        = link_to '<strong>Hanna Nouveau</strong> RDoc template', 'https://github.com/rdoc/hanna-nouveau'


### PR DESCRIPTION
Hi,

this PR changes the footer of the template to reflect its correct name “Hanna Nouveau“ and links to the proper repository. Before, it just said “Hanna” and linked to mislav’s original Hanna repository, which is misleading.

Greetings
Marvin