### PR TITLE
Break words of inline code tags

### DIFF
--- a/lib/hanna-nouveau/template_files/styles.css
+++ b/lib/hanna-nouveau/template_files/styles.css
@@ -202,6 +202,7 @@ div.header {
     font: 14px Monaco, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace;
     background: #ffffe3;
     padding: 2px 3px;
+    overflow-wrap: break-word;
     line-height: 1.4; }
   #content h1 code, #content h1 tt, #content h2 code, #content h2 tt, #content h3 code, #content h3 tt, #content h4 code, #content h4 tt, #content h5 code, #content h5 tt, #content h6 code, #content h6 tt {
     font-size: 1.1em; }


### PR DESCRIPTION
This prevents long code tags from extending the viewport on mobile, causing horizontal scrolling.

Before:

<img width="436" alt="Screenshot 2023-07-04 at 22 44 20" src="https://github.com/jeremyevans/hanna-nouveau/assets/795488/57b9862b-80bf-472b-ac28-8db9ed4e9df6">

After:

<img width="445" alt="Screenshot 2023-07-04 at 22 44 28" src="https://github.com/jeremyevans/hanna-nouveau/assets/795488/bae9c5d0-c847-45f4-bfe2-417daef7ffe6">
